### PR TITLE
google font SASSC syntax erro solved

### DIFF
--- a/app/assets/stylesheets/config/_fonts.scss
+++ b/app/assets/stylesheets/config/_fonts.scss
@@ -1,6 +1,8 @@
 // Import Google fonts
 // E.G. @import url('https://fonts.googleapis.com/css?family=Nunito:400,700|Work+Sans:400,700&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,500;0,700;0,900;1,100;1,300&display=swap');
+// @import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,500;0,700;0,900;1,100;1,300&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@600&family=Roboto:wght@100&display=swap');
+
 
 
 // Todo: Define fonts for body and headers
@@ -9,8 +11,10 @@
 // $headers-font: "Nunito", "Helvetica", "sans-serif";
 
 // Todo: Define fonts for body and headers for the ZOO APP
-$body-font: "Roboto, "sans-serif;
-$headers-font: "Roboto, "sans-serif";
+// $body-font: 'Roboto', "sans-serif;
+// $headers-font: 'Roboto', "sans-serif";
+$body-font: 'Roboto', 'Lato';
+$headers-font: 'Roboto';
 
 
 


### PR DESCRIPTION
is misleading but this is a ROBOTO first font + OPEN SANS touch
@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@600&family=Roboto:wght@100&display=swap');

source
https://fonts.google.com/specimen/Roboto?sidebar.open=true&selection.family=Open+Sans:wght@600|Roboto:wght@100&query=Roboto#standard-styles